### PR TITLE
Unescaped quote in complex-filenames.hrx

### DIFF
--- a/example/complex-filenames.hrx
+++ b/example/complex-filenames.hrx
@@ -1,7 +1,7 @@
 <===> .dir/.../.file
 Filenames may contain dots, as long as they're not "." or "..".
 
-<===> ~`!@#$%^&*()_-+= {}[]|;\"'<,>.?
+<===> ~`!@#$%^&*()_-+= {}[]|;"'<,>.?
 Filenames can contain all kinds of weird characters.
 
 <===> ☃

--- a/example/complex-filenames.hrx
+++ b/example/complex-filenames.hrx
@@ -1,7 +1,7 @@
 <===> .dir/.../.file
 Filenames may contain dots, as long as they're not "." or "..".
 
-<===> ~`!@#$%^&*()_-+= {}[]|;"'<,>.?
+<===> ~`!@#$%^&*()_-+= {}[]|;\"'<,>.?
 Filenames can contain all kinds of weird characters.
 
 <===> ☃

--- a/example/quoted-filename.hrx
+++ b/example/quoted-filename.hrx
@@ -4,5 +4,5 @@ Filenames may contain spaces as long as they're quoted.
 <===> "file\"name"
 Filenames may contain quotes as long as they're escaped.
 
-<===> file\"name
+<===> file\"name2
 Even unquoted filenames may contain escaped quotes.

--- a/example/quoted-filename.hrx
+++ b/example/quoted-filename.hrx
@@ -1,8 +1,0 @@
-<===> "path to/my file"
-Filenames may contain spaces as long as they're quoted.
-
-<===> "file\"name"
-Filenames may contain quotes as long as they're escaped.
-
-<===> file\"name2
-Even unquoted filenames may contain escaped quotes.


### PR DESCRIPTION
In the file `quoted-filename.hrx` it's implied that a quote character in the middle of a filename should be escaped.
In the file `complex-filenames.hrx` one of the filenames is ``~`!@#$%^&*()_-+= {}[]|;"'<,>.?`` which contains an unescaped quote that's in the middle of the filename.

This PR changes that filename to ``~`!@#$%^&*()_-+= {}[]|;\"'<,>.?`` where the quote is escaped.
